### PR TITLE
Fix extraction and add tests

### DIFF
--- a/agents/auto_connector.py
+++ b/agents/auto_connector.py
@@ -8,7 +8,7 @@ def parse_connection_request(message):
     if "imap" in message.lower():
         config["type"] = "imap"
         config["ssl"] = True if "ssl" in message.lower() else False
-        config["user"] = extract_field(message, r"[\w\.]+@[\w\.]+")
+        config["user"] = extract_field(message, r"([\w\.]+@[\w\.]+)")
         config["password"] = extract_field(message, r"heslo\s+je\s+(\S+)")
         config["server"] = extract_field(message, r"server\s+(\S+)")
         config["port"] = int(extract_field(message, r"port\s+(\d+)") or 993)
@@ -16,7 +16,12 @@ def parse_connection_request(message):
 
 def extract_field(text, pattern):
     match = re.search(pattern, text, re.IGNORECASE)
-    return match.group(1) if match else None
+    if not match:
+        return None
+    try:
+        return match.group(1)
+    except IndexError:
+        return None
 
 def handle_message(message):
     config = parse_connection_request(message)

--- a/tests/test_auto_connector.py
+++ b/tests/test_auto_connector.py
@@ -1,0 +1,11 @@
+import unittest
+from agents import auto_connector
+
+class AutoConnectorTest(unittest.TestCase):
+    def test_parse_extracts_email(self):
+        msg = "Pripoj se na IMAP e-mail jiri@firma.cz server mail.firma.cz port 993 SSL heslo je tajne123"
+        cfg = auto_connector.parse_connection_request(msg)
+        self.assertEqual(cfg.get("user"), "jiri@firma.cz")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support capturing user email by adjusting regex
- safely get match group in helper
- test IMAP connection parsing

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687132b1fec083279105a88a891c8c94