### PR TITLE
Ensure config directory exists before writing connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Připoj se na e-mail jiri@firma.cz, server mail.firma.cz, port 993, SSL, heslo j
 - `agents/auto_connector.py` – hlavní rozhraní, které rozpozná typ služby a vytvoří konfiguraci.
 - `agents/email_agent.py` – jednoduchý IMAP klient.
 - `config/connections.json` – uložené připojení.
+  Soubor je vygenerován při volání `handle_message` a je uložen v adresáři `config/`.
 - `secrets/token.json` – připraveno pro případné API tokeny (např. Google Calendar).
 
 ## ▶️ Použití

--- a/agents/auto_connector.py
+++ b/agents/auto_connector.py
@@ -1,6 +1,7 @@
 
 import re
 import json
+import os
 from agents import email_agent
 
 def parse_connection_request(message):
@@ -26,6 +27,7 @@ def extract_field(text, pattern):
 def handle_message(message):
     config = parse_connection_request(message)
     if config.get("type") == "imap":
+        os.makedirs("config", exist_ok=True)
         with open("config/connections.json", "w") as f:
             json.dump(config, f, indent=2)
         return email_agent.connect(config)

--- a/tests/test_auto_connector.py
+++ b/tests/test_auto_connector.py
@@ -1,4 +1,6 @@
 import unittest
+import os
+from unittest import mock
 from agents import auto_connector
 
 class AutoConnectorTest(unittest.TestCase):
@@ -6,6 +8,18 @@ class AutoConnectorTest(unittest.TestCase):
         msg = "Pripoj se na IMAP e-mail jiri@firma.cz server mail.firma.cz port 993 SSL heslo je tajne123"
         cfg = auto_connector.parse_connection_request(msg)
         self.assertEqual(cfg.get("user"), "jiri@firma.cz")
+
+    def test_handle_message_creates_file(self):
+        msg = (
+            "Pripoj se na IMAP e-mail test@firma.cz "
+            "server mail.example.com port 993 SSL heslo je tajne123"
+        )
+        path = "config/connections.json"
+        if os.path.exists(path):
+            os.remove(path)
+        with mock.patch("agents.email_agent.connect", return_value="ok"):
+            auto_connector.handle_message(msg)
+        self.assertTrue(os.path.exists(path))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- create the `config` directory before saving connections
- describe the generated file location in README
- add a unit test ensuring `handle_message` creates the file

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687136773108832780995be6104e11a9