### PR TITLE
Improve auto_connector parsing

### DIFF
--- a/agents/auto_connector.py
+++ b/agents/auto_connector.py
@@ -1,28 +1,59 @@
 
-import re
 import json
 import os
+import shlex
 from agents import email_agent
+
+try:
+    import validators
+except Exception:  # pragma: no cover - fallback for environments without package
+    import re
+
+    class validators:  # type: ignore
+        @staticmethod
+        def domain(value: str) -> bool:
+            return bool(re.match(r"^[A-Za-z0-9.-]+\.[A-Za-z]{2,}$", value))
 
 def parse_connection_request(message):
     config = {}
     if "imap" in message.lower():
         config["type"] = "imap"
-        config["ssl"] = True if "ssl" in message.lower() else False
-        config["user"] = extract_field(message, r"([\w\.]+@[\w\.]+)")
-        config["password"] = extract_field(message, r"heslo\s+je\s+(\S+)")
-        config["server"] = extract_field(message, r"server\s+(\S+)")
-        config["port"] = int(extract_field(message, r"port\s+(\d+)") or 993)
+        tokens = [t.strip(",.;") for t in shlex.split(message)]
+
+        config["ssl"] = any(t.lower() == "ssl" for t in tokens)
+
+        # locate email address
+        config["user"] = next((t for t in tokens if "@" in t), None)
+
+        # extract password "heslo je <pwd>"
+        try:
+            idx = next(i for i, t in enumerate(tokens) if t.lower() == "heslo")
+            if tokens[idx + 1].lower() == "je":
+                config["password"] = tokens[idx + 2].strip(",.;")
+        except (StopIteration, IndexError):
+            pass
+
+        # extract server hostname
+        try:
+            idx = next(i for i, t in enumerate(tokens) if t.lower() == "server")
+            host = tokens[idx + 1]
+            if validators.domain(host):
+                config["server"] = host
+        except (StopIteration, IndexError):
+            pass
+
+        # extract and validate port
+        port = None
+        try:
+            idx = next(i for i, t in enumerate(tokens) if t.lower() == "port")
+            port_candidate = int(tokens[idx + 1])
+            if 1 <= port_candidate <= 65535:
+                port = port_candidate
+        except (StopIteration, IndexError, ValueError):
+            pass
+        config["port"] = port if port is not None else 993
     return config
 
-def extract_field(text, pattern):
-    match = re.search(pattern, text, re.IGNORECASE)
-    if not match:
-        return None
-    try:
-        return match.group(1)
-    except IndexError:
-        return None
 
 def handle_message(message):
     config = parse_connection_request(message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 # Requires Python >=3.11
+validators


### PR DESCRIPTION
## Summary
- parse connection requests with `shlex` instead of regex
- add hostname validation with `validators.domain`
- verify that the port is within 1-65535
- document validators in requirements

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68722e0524948327bdd517d5a57f40d6