### PR TITLE
Improve password handling

### DIFF
--- a/agents/auto_connector.py
+++ b/agents/auto_connector.py
@@ -2,7 +2,12 @@
 import json
 import os
 import shlex
+import base64
+import uuid
+import logging
 from agents import email_agent
+
+logging.basicConfig(level=logging.INFO)
 
 try:
     import validators
@@ -55,11 +60,35 @@ def parse_connection_request(message):
     return config
 
 
+def store_password(password: str) -> str:
+    """Store password in secrets file and return identifier."""
+    os.makedirs("secrets", exist_ok=True)
+    path = os.path.join("secrets", "secrets.json")
+    try:
+        with open(path) as f:
+            secrets = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        secrets = {}
+
+    secret_id = str(uuid.uuid4())
+    secrets[secret_id] = base64.b64encode(password.encode()).decode()
+    with open(path, "w") as f:
+        json.dump(secrets, f, indent=2)
+    return secret_id
+
+
 def handle_message(message):
     config = parse_connection_request(message)
     if config.get("type") == "imap":
+        password = config.pop("password", None)
+        if password:
+            secret_id = store_password(password)
+            logging.info("IMAP password stored with id %s", secret_id)
+            config["password_id"] = secret_id
+
         os.makedirs("config", exist_ok=True)
         with open("config/connections.json", "w") as f:
             json.dump(config, f, indent=2)
-        return email_agent.connect(config)
+
+        return email_agent.connect({**config, "password": password} if password else config)
     return "Nepodporovaný typ služby."


### PR DESCRIPTION
## Summary
- store passwords in a separate secrets file, obfuscating the value
- record only that a password was stored when handling messages

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68722f1a362083279ea9590f490de1cc