### PR TITLE
Isolate file creation in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated connection configurations
+config/*.json

--- a/tests/test_auto_connector.py
+++ b/tests/test_auto_connector.py
@@ -1,9 +1,19 @@
 import unittest
 import os
+import tempfile
 from unittest import mock
 from agents import auto_connector
 
 class AutoConnectorTest(unittest.TestCase):
+    def setUp(self):
+        self.orig_cwd = os.getcwd()
+        self.tmpdir = tempfile.TemporaryDirectory()
+        os.chdir(self.tmpdir.name)
+
+    def tearDown(self):
+        os.chdir(self.orig_cwd)
+        self.tmpdir.cleanup()
+
     def test_parse_extracts_email(self):
         msg = "Pripoj se na IMAP e-mail jiri@firma.cz server mail.firma.cz port 993 SSL heslo je tajne123"
         cfg = auto_connector.parse_connection_request(msg)
@@ -15,8 +25,6 @@ class AutoConnectorTest(unittest.TestCase):
             "server mail.example.com port 993 SSL heslo je tajne123"
         )
         path = "config/connections.json"
-        if os.path.exists(path):
-            os.remove(path)
         with mock.patch("agents.email_agent.connect", return_value="ok"):
             auto_connector.handle_message(msg)
         self.assertTrue(os.path.exists(path))


### PR DESCRIPTION
## Summary
- use `TemporaryDirectory` in `AutoConnectorTest`
- ignore config `.json` files

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872390cf2e48327ab2d0171f4933ab7