### PR TITLE
Add service registry to auto_connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,17 @@ from agents import auto_connector
 auto_connector.handle_message("Pripoj se na IMAP e-mail...")
 ```
 
+## ➕ Registrace dalších agentů
+
+Nového agenta lze přidat přidáním záznamu do slovníku `SERVICE_REGISTRY`
+v souboru `agents/auto_connector.py`. Klíčem je název služby vracený z
+`parse_connection_request` a hodnotou funkce, která přijímá konfiguraci.
+
+```python
+from agents import my_agent
+SERVICE_REGISTRY["chat"] = my_agent.handle
+```
+
+Po rozšíření `parse_connection_request` o daný typ tak `handle_message`
+automaticky zavolá příslušného agenta.
+


### PR DESCRIPTION
## Summary
- add SERVICE_REGISTRY and calendar handler
- update handle_message to use registered handlers
- support calendar detection in parse_connection_request
- document how to register additional agents

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687241d27cd88327bf749b2a88c7abbd