### PR TITLE
Support config param for calendar events

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,14 @@ auto_connector.handle_message("Pripoj se na IMAP e-mail...")
 
 Nového agenta lze přidat přidáním záznamu do slovníku `SERVICE_REGISTRY`
 v souboru `agents/auto_connector.py`. Klíčem je název služby vracený z
-`parse_connection_request` a hodnotou funkce, která přijímá konfiguraci.
+`parse_connection_request` a hodnotou funkce, která **přijímá jeden argument
+s konfigurací**. Pokud funkce žádné parametry nepotřebuje, obalte ji
+například pomocí `lambda` tak, aby i přesto přijímala konfiguraci.
 
 ```python
 from agents import my_agent
 SERVICE_REGISTRY["chat"] = my_agent.handle
+SERVICE_REGISTRY["stats"] = lambda cfg: my_agent.simple_stats()
 ```
 
 Po rozšíření `parse_connection_request` o daný typ tak `handle_message`

--- a/agents/calendar_agent.py
+++ b/agents/calendar_agent.py
@@ -1,7 +1,14 @@
 
 from datetime import datetime, timedelta
 
-def list_events():
+
+def list_events(config=None):
+    """Return simulated calendar events.
+
+    The optional ``config`` argument is ignored but allows the function to be
+    used with :mod:`agents.auto_connector`, which always passes a configuration
+    dictionary to handler callables.
+    """
     # Dummy funkce – simulace událostí
     now = datetime.now()
     return [

--- a/tests/test_auto_connector.py
+++ b/tests/test_auto_connector.py
@@ -45,5 +45,13 @@ class AutoConnectorTest(unittest.TestCase):
         cfg = auto_connector.parse_connection_request(msg)
         self.assertEqual(cfg.get("port"), 993)
 
+    def test_calendar_request_calls_list_events(self):
+        msg = "Zobraz kalendar"
+        m = mock.Mock(return_value=["ok"])
+        with mock.patch.dict(auto_connector.SERVICE_REGISTRY, {"calendar": m}):
+            result = auto_connector.handle_message(msg)
+        self.assertEqual(result, ["ok"])
+        m.assert_called_once_with({"type": "calendar"})
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow `calendar_agent.list_events` to accept an optional config argument
- clarify README about handlers receiving configuration and show lambda wrapper example
- ensure calendar requests call the right handler

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872517a7ad48327a6dee204709de1a2