### PR TITLE
Use wrapper lambdas for handlers

### DIFF
--- a/agents/auto_connector.py
+++ b/agents/auto_connector.py
@@ -11,8 +11,8 @@ logging.basicConfig(level=logging.INFO)
 
 # Map service types to handler callables
 SERVICE_REGISTRY = {
-    "email": email_agent.connect,
-    "calendar": calendar_agent.list_events,
+    "email": lambda cfg: email_agent.connect(cfg),
+    "calendar": lambda cfg: calendar_agent.list_events(cfg),
 }
 
 try:

--- a/tests/test_auto_connector.py
+++ b/tests/test_auto_connector.py
@@ -25,8 +25,9 @@ class AutoConnectorTest(unittest.TestCase):
             "server mail.example.com port 993 SSL heslo je tajne123"
         )
         path = "config/connections.json"
-        with mock.patch("agents.email_agent.connect", return_value="ok"):
+        with mock.patch("agents.email_agent.connect", return_value="ok") as m:
             auto_connector.handle_message(msg)
+            m.assert_called_once()
         self.assertTrue(os.path.exists(path))
 
     def test_invalid_server_name(self):

--- a/tests/test_email_agent.py
+++ b/tests/test_email_agent.py
@@ -49,13 +49,14 @@ class EmailAgentTest(unittest.TestCase):
             "server mail.example.com port 993 SSL heslo je tajne123"
         )
         path = "config/connections.json"
-        with mock.patch("agents.email_agent.connect", return_value="ok"):
+        with mock.patch("agents.email_agent.connect", return_value="ok") as m:
             auto_connector.handle_message(msg)
             with open(path) as f:
                 first = json.load(f)
             auto_connector.handle_message(msg)
             with open(path) as f:
                 second = json.load(f)
+            self.assertEqual(m.call_count, 2)
         first.pop("password_id", None)
         second.pop("password_id", None)
         self.assertEqual(first, second)


### PR DESCRIPTION
## Summary
- wrap registry functions so patches work
- ensure patched handlers are invoked in tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872527044cc832791de7109371c6656