### PR TITLE
Add calendar connector file test

### DIFF
--- a/tests/test_auto_connector.py
+++ b/tests/test_auto_connector.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import tempfile
+import json
 from unittest import mock
 from agents import auto_connector
 
@@ -53,6 +54,18 @@ class AutoConnectorTest(unittest.TestCase):
             result = auto_connector.handle_message(msg)
         self.assertEqual(result, ["ok"])
         m.assert_called_once_with({"type": "calendar"})
+
+    def test_calendar_message_writes_clean_config(self):
+        msg = "Zobraz kalendar"
+        expected = ["dummy"]
+        path = "config/connections.json"
+        with mock.patch("agents.calendar_agent.list_events", return_value=expected) as m:
+            result = auto_connector.handle_message(msg)
+        self.assertEqual(result, expected)
+        m.assert_called_once_with({"type": "calendar"})
+        with open(path) as f:
+            cfg = json.load(f)
+        self.assertEqual(cfg, {"type": "calendar"})
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add json import for tests
- verify calendar message writes clean config and returns calendar events

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687253acaa2c8327936d56328350d85e