### PR TITLE
Introduce CalendarAgent class

### DIFF
--- a/agents/auto_connector.py
+++ b/agents/auto_connector.py
@@ -5,14 +5,17 @@ import shlex
 import base64
 import uuid
 import logging
-from agents import email_agent, calendar_agent
+from agents import email_agent
+from agents.calendar_agent import CalendarAgent
 
 logging.basicConfig(level=logging.INFO)
 
 # Map service types to handler callables
+calendar_service = CalendarAgent()
+
 SERVICE_REGISTRY = {
     "email": lambda cfg: email_agent.connect(cfg),
-    "calendar": lambda cfg: calendar_agent.list_events(cfg),
+    "calendar": lambda cfg: calendar_service.list_events(cfg),
 }
 
 try:

--- a/agents/calendar_agent.py
+++ b/agents/calendar_agent.py
@@ -1,35 +1,47 @@
-
+import json
+import os
 from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
 
 
-def list_events(config=None):
-    """Return simulated calendar events.
+class CalendarAgent:
+    """Simple calendar agent preparing for future API integration."""
 
-    The optional ``config`` argument is ignored but allows the function to be
-    used with :mod:`agents.auto_connector`, which always passes a configuration
-    dictionary to handler callables.
-    """
-    # Dummy funkce – simulace událostí
-    now = datetime.now()
-    return [
-        {
-            "title": "Porada s týmem",
-            "start": now.strftime("%Y-%m-%d %H:%M"),
-            "end": (now + timedelta(hours=1)).strftime("%Y-%m-%d %H:%M")
-        },
-        {
-            "title": "Call s klientem",
-            "start": (now + timedelta(hours=2)).strftime("%Y-%m-%d %H:%M"),
-            "end": (now + timedelta(hours=3)).strftime("%Y-%m-%d %H:%M")
+    def __init__(self, credentials_file: str = "config/calendar_credentials.json") -> None:
+        self.credentials_file = credentials_file
+        os.makedirs(os.path.dirname(credentials_file), exist_ok=True)
+        if not os.path.exists(credentials_file):
+            creds = {"token_path": "secrets/token.json"}
+            with open(credentials_file, "w") as f:
+                json.dump(creds, f, indent=2)
+
+    def list_events(self, config: Optional[Dict[str, Any]] = None) -> List[Dict[str, str]]:
+        """Return simulated calendar events."""
+        now = datetime.now()
+        return [
+            {
+                "title": "Porada s týmem",
+                "start": now.strftime("%Y-%m-%d %H:%M"),
+                "end": (now + timedelta(hours=1)).strftime("%Y-%m-%d %H:%M"),
+            },
+            {
+                "title": "Call s klientem",
+                "start": (now + timedelta(hours=2)).strftime("%Y-%m-%d %H:%M"),
+                "end": (now + timedelta(hours=3)).strftime("%Y-%m-%d %H:%M"),
+            },
+        ]
+
+    def create_event(
+        self,
+        title: str,
+        start_time: datetime,
+        duration_minutes: int = 60,
+    ) -> Dict[str, str]:
+        """Return a simulated created event."""
+        end_time = start_time + timedelta(minutes=duration_minutes)
+        return {
+            "title": title,
+            "start": start_time.strftime("%Y-%m-%d %H:%M"),
+            "end": end_time.strftime("%Y-%m-%d %H:%M"),
+            "status": "created",
         }
-    ]
-
-def create_event(title, start_time, duration_minutes=60):
-    # Dummy funkce – neukládá, jen simuluje vytvoření
-    end_time = start_time + timedelta(minutes=duration_minutes)
-    return {
-        "title": title,
-        "start": start_time.strftime("%Y-%m-%d %H:%M"),
-        "end": end_time.strftime("%Y-%m-%d %H:%M"),
-        "status": "created"
-    }

--- a/tests/test_auto_connector.py
+++ b/tests/test_auto_connector.py
@@ -59,7 +59,7 @@ class AutoConnectorTest(unittest.TestCase):
         msg = "Zobraz kalendar"
         expected = ["dummy"]
         path = "config/connections.json"
-        with mock.patch("agents.calendar_agent.list_events", return_value=expected) as m:
+        with mock.patch.object(auto_connector.calendar_service, "list_events", return_value=expected) as m:
             result = auto_connector.handle_message(msg)
         self.assertEqual(result, expected)
         m.assert_called_once_with({"type": "calendar"})

--- a/tests/test_calendar_agent.py
+++ b/tests/test_calendar_agent.py
@@ -1,0 +1,42 @@
+import os
+import json
+import tempfile
+import unittest
+from datetime import datetime
+
+from agents.calendar_agent import CalendarAgent
+
+
+class CalendarAgentTest(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.orig_cwd = os.getcwd()
+        os.chdir(self.tmpdir.name)
+
+    def tearDown(self):
+        os.chdir(self.orig_cwd)
+        self.tmpdir.cleanup()
+
+    def test_credentials_file_created(self):
+        agent = CalendarAgent()
+        agent.list_events()
+        path = "config/calendar_credentials.json"
+        self.assertTrue(os.path.exists(path))
+        with open(path) as f:
+            data = json.load(f)
+        self.assertIn("token_path", data)
+
+    def test_create_event_structure(self):
+        agent = CalendarAgent()
+        start = datetime(2024, 1, 1, 10, 0)
+        result = agent.create_event("Meet", start, 30)
+        self.assertEqual(result["title"], "Meet")
+        self.assertEqual(result["start"], "2024-01-01 10:00")
+        self.assertEqual(result["end"], "2024-01-01 10:30")
+        self.assertEqual(result["status"], "created")
+
+
+def load_tests(loader, tests, pattern):
+    return unittest.TestSuite([
+        loader.loadTestsFromTestCase(CalendarAgentTest),
+    ])


### PR DESCRIPTION
## Summary
- implement `CalendarAgent` class with `list_events` and `create_event`
- store future credential info in `config/calendar_credentials.json`
- integrate `CalendarAgent` with `auto_connector`
- update auto connector tests and add unit tests for `CalendarAgent`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687254718254832790882e74fdbb406a